### PR TITLE
fix: support different lucide-static icon versions

### DIFF
--- a/lib/lucide_icons/icon.ex
+++ b/lib/lucide_icons/icon.ex
@@ -20,6 +20,7 @@ defmodule Lucideicons.Icon do
   @json (cond do
            Code.ensure_loaded?(JSON) -> JSON
            Code.ensure_loaded?(Jason) -> Jason
+           Code.ensure_loaded?(Poison) -> Poison
            true -> raise "need a JSON library available, either JSON or Jason"
          end)
 
@@ -77,6 +78,11 @@ defmodule Lucideicons.Icon do
   end
 
   def insert_attrs(<<@license, rest::binary>>, attrs) do
+    insert_attrs(rest, attrs)
+  end
+
+  def insert_attrs(icon, attrs) when is_binary(icon) do
+    [_license, rest] = String.split(icon, "\n", parts: 2)
     insert_attrs(rest, attrs)
   end
 end

--- a/test/lucide_icons_test.exs
+++ b/test/lucide_icons_test.exs
@@ -36,4 +36,15 @@ defmodule LucideiconsTest do
 
     assert html =~ ~s(<svg aria-hidden="false")
   end
+
+  test "renders icon that may be deprecated, with different package version" do
+    assigns = %{}
+
+    html =
+      rendered_to_string(~H"""
+      <Lucideicons.circle_alert />
+      """)
+
+    assert html =~ "<svg"
+  end
 end


### PR DESCRIPTION
`lucide-static` may deprecate some icons but maintain them using a different library version on the license header on svgs than the package latest version, for example `circle-alert` that have a `v0.516.0` version header but the latest version we're using to compile live view components is `v0.528.0`, which causes a `FunctionClauseError` since we extract the license from the svg binary to construct the html part and inject attributes on `lib/lucide_icons/icon.ex:75`

Close #9 too
