### PR TITLE
feat: Normalize class assign to match Phoenix conditional-class patterns

### DIFF
--- a/lib/lucide_icons/icon.ex
+++ b/lib/lucide_icons/icon.ex
@@ -111,7 +111,11 @@ defmodule Lucideicons.Icon do
   end
 
   defp merge_assigns(%{class: class} = assigns, %{"class" => lucide_class} = svg_attrs) do
-    class = Enum.join([lucide_class, class], " ")
+    class =
+      [lucide_class, normalize_class(class)]
+      |> Enum.reject(&(&1 in [nil, ""]))
+      |> Enum.join(" ")
+
     assigns = Map.new(assigns, fn {k, v} -> {format_attr_key(k), v} end)
 
     svg_attrs
@@ -123,4 +127,21 @@ defmodule Lucideicons.Icon do
     assigns = Map.new(assigns, fn {k, v} -> {format_attr_key(k), v} end)
     Map.merge(svg_attrs, assigns)
   end
+
+  # Accept the same `class` shapes Phoenix HEEx accepts on native HTML
+  # elements: binary | list (possibly nested) | nil | false. Falsy and empty
+  # entries are dropped, lists flattened, joined with spaces. Without this,
+  # `class={[base, @flag && "extra"]}` — the standard Phoenix conditional
+  # class pattern — crashes the icon at render time when @flag is false,
+  # because Enum.join then receives a list containing `false`.
+  defp normalize_class(class) when is_binary(class), do: class
+
+  defp normalize_class(class) when is_list(class) do
+    class
+    |> List.flatten()
+    |> Enum.reject(&(&1 in [false, nil, ""]))
+    |> Enum.join(" ")
+  end
+
+  defp normalize_class(_), do: ""
 end

--- a/lib/lucide_icons/icon.ex
+++ b/lib/lucide_icons/icon.ex
@@ -128,12 +128,6 @@ defmodule Lucideicons.Icon do
     Map.merge(svg_attrs, assigns)
   end
 
-  # Accept the same `class` shapes Phoenix HEEx accepts on native HTML
-  # elements: binary | list (possibly nested) | nil | false. Falsy and empty
-  # entries are dropped, lists flattened, joined with spaces. Without this,
-  # `class={[base, @flag && "extra"]}` — the standard Phoenix conditional
-  # class pattern — crashes the icon at render time when @flag is false,
-  # because Enum.join then receives a list containing `false`.
   defp normalize_class(class) when is_binary(class), do: class
 
   defp normalize_class(class) when is_list(class) do

--- a/test/lucide_icons_test.exs
+++ b/test/lucide_icons_test.exs
@@ -73,6 +73,64 @@ defmodule LucideiconsTest do
     assert html =~ "custom-class"
   end
 
+  describe "class normalization" do
+    test "accepts a flat class list" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <Lucideicons.activity class={["h-4 w-4", "text-blue-500"]} />
+        """)
+
+      assert html =~ ~s(class="lucide lucide-activity h-4 w-4 text-blue-500")
+    end
+
+    test "drops `false` entries (Phoenix conditional-class pattern)" do
+      assigns = %{filled?: false}
+
+      html =
+        rendered_to_string(~H"""
+        <Lucideicons.heart class={["size-4", @filled? && "fill-current"]} />
+        """)
+
+      assert html =~ ~s(class="lucide lucide-heart size-4")
+      refute html =~ "false"
+    end
+
+    test "drops `nil` and empty-string entries" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <Lucideicons.heart class={["size-4", nil, ""]} />
+        """)
+
+      assert html =~ ~s(class="lucide lucide-heart size-4")
+    end
+
+    test "flattens nested lists" do
+      assigns = %{flag?: true}
+
+      html =
+        rendered_to_string(~H"""
+        <Lucideicons.heart class={[["size-4", "transition"], @flag? && "fill-current"]} />
+        """)
+
+      assert html =~ ~s(class="lucide lucide-heart size-4 transition fill-current")
+    end
+
+    test "handles nil class" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <Lucideicons.heart class={nil} />
+        """)
+
+      assert html =~ ~s(class="lucide lucide-heart")
+    end
+  end
+
   # https://github.com/zoedsoupe/lucide_icons/issues/24
   test "renders icon correctly with span element after it" do
     assigns = %{}


### PR DESCRIPTION
## Summary

`Lucideicons.Icon.merge_assigns/2` currently joins the user's `class` assign directly via `Enum.join`. That crashes at render time on any class value other than a plain string — including the standard Phoenix conditional-class pattern that callers naturally reach for:

```heex
<Lucideicons.heart class={["size-4", @filled? && "fill-current"]} />
```

When `@filled?` is `false`, the list contains `false`, and `Enum.join/2` calls `List.to_string/1` on it:

```
** (ArgumentError) cannot convert the given list to a string.

To be converted to a string, a list must either be empty or only
contain the following elements:

  * strings
  * integers representing Unicode code points
  * a list containing one of these three elements

Please check the given list or call inspect/1 to get the list representation, got:

["size-4", false]
```

Phoenix HEEx's tag engine handles class normalization for *native HTML elements* (`<div>`, `<button>`, etc.) but **not** for function components — those just receive the raw assigns map. So `<Lucideicons.heart class={[...]}>` ends up calling `Enum.join` on a list it can't handle.

The failure is render-time only — the code compiles, the page renders fine when the boolean is true, and crashes the moment the data flips. In a recent migration we hit this across ~200 callsites that all looked correct.

## Fix

Add a `normalize_class/1` helper that accepts the same shapes Phoenix's tag engine accepts:

- binary
- list (including nested lists)
- `nil`, `false`, `""` entries (silently dropped)

The helper flattens, filters falsy/empty, and joins with spaces *before* the merge with `lucide_class`. Existing string class values pass through unchanged.

## Tests

Added a `describe "class normalization"` block with five cases:

- flat list of strings
- conditional list with a `false` entry
- list with `nil`/`""` entries
- nested list (`[[a, b], c]`)
- `nil` class

All 11 tests pass locally (6 existing + 5 new).

## Compat

Backwards-compatible. Existing callers that pass `class="h-4 w-4"` see no behavior change. Callers that previously had to pre-join their class lists manually (or hit the crash) now work without changes.

## Out of scope

Not changing the `attr :class` declaration or formally documenting the accepted shapes — minimal surface change. Happy to extend if you'd prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Icons now accept CSS class input in multiple flexible formats (strings, lists, nested/conditional lists), automatically flattening and filtering out empty or falsey entries for correct final class output.

* **Tests**
  * Added comprehensive tests covering class input normalization, including flat lists, conditional entries, nested lists, empty values, and nil handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zoedsoupe/lucide_icons/pull/52)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->